### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:5
+
+CMD ["node", "river5.js"]
+EXPOSE 1337
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package.json /app/package.json
+
+RUN npm install
+
+COPY . /app
+


### PR DESCRIPTION
This allows us to deploy River5 as a Docker container - an isolated, controlled sandbox environment. The container image can then be deployed to a variety of services including Amazon's EC2 Container Service and Docker Cloud. Or you can run River5 locally without having to install Node.js - it's already inside the container image that gets built from this Dockerfile.

To build a container image for your own river, you'll need to [install Docker](https://www.docker.com/products/overview#/install_the_platform). 

Once Docker is working, we create an image, which we then run to create a container (essentially the Node.js process in a sandbox):
1. Open a terminal
2. Navigate to your `river5` folder (i.e. your clone of this repo)
3. Run `docker build -t river5:latest .`

Then run the image to create a container with the Node.js process inside:

```
docker run -p 1337:1337 river5:latest
```

Browse to http://localhost:1337/ and there's your river!

A few notes:
- This Dockerfile assumes that your `config.js` is set to use port 1337, which is the default.
- You will need to configure your river before you build the container. The `docker build` process then encapsulates your config inside the image.
- Getting Docker working is not always trivial, though there are reasonable installers for common OSs at docker.com.
