### PR TITLE
Fixing readFeed: error == Cannot read property 'pubDate' of null

### DIFF
--- a/lib/feedtools.js
+++ b/lib/feedtools.js
@@ -1,4 +1,4 @@
- 
+
 /*  The MIT License (MIT)
 	Copyright (c) 2014-2016 Dave Winer
 	
@@ -599,6 +599,9 @@ var whenServerStart = new Date ();
 				feedparser.on ("readable", function () {
 					try {
 						var item = this.read (), flnew;
+						if (null === item) {
+							return;
+							}
 						if (new Date (item.pubDate) > new Date (feed.stats.mostRecentPubDate)) {
 							feed.stats.mostRecentPubDate = item.pubDate;
 							feedstats.mostRecentPubDate = item.pubDate;


### PR DESCRIPTION
Frank McPherson posted on the Google Group in thread [River5.js shutdown](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/river5/5igaA8LIUgs/tL-Z7cZeCgAJ) that while debugging an issue he had hundreds of errors in the logfile saying:

>  readFeed: error == Cannot read property 'pubDate' of null

I personally didn't see any of these errors in my feed, but looking at the code and reading the documentation on [Node Streams readable event](https://nodejs.org/api/stream.html#stream_event_readable) I found:

>  In the former case, stream.read() will return the available data. In the latter case, stream.read() will return null.

My guess is there is some edge case with fetching an empty feed or something.

It's a simple enough check to see if item is null. If so we just return and don't do anything with it.