### PR TITLE
Treating rssCloud pleaseNotify response with success=false as an error

### DIFF
--- a/lib/feedtools.js
+++ b/lib/feedtools.js
@@ -1642,7 +1642,16 @@ var whenServerStart = new Date ();
 				flFeedsArrayChanged = true; 
 				}
 			try {
-				if (!err) {
+				body = JSON.parse (body);
+				if (err) {
+					console.log ("pleaseNotify: urlFeed == " + urlFeed + ", err.message == " + err.message + ".");
+					recordErrorStats ();
+					}
+				else if (false === body.success) {
+					console.log ("pleaseNotify: urlFeed == " + urlFeed + ", body.msg == " + body.msg + ".");
+					recordErrorStats ();
+					}
+				else {
 					feedstats.ctConsecutiveCloudRenewErrors = 0;
 					flFeedsArrayChanged = true; //because we modified feedstats
 					console.log ("pleaseNotify: " + urlFeed);
@@ -1650,10 +1659,7 @@ var whenServerStart = new Date ();
 						callback ();
 						}
 					}
-				else {
-					console.log ("pleaseNotify: urlFeed == " + urlFeed + ", err.message == " + err.message + ".");
-					recordErrorStats ();
-					}
+
 				}
 			catch (err) {
 				console.log ("pleaseNotify: urlFeed == " + urlFeed + ", err.message == " + err.message);


### PR DESCRIPTION
Previously when I was debugging the issue with rssCloud not working I found that if the pleaseNotify request was technically a success (Status Code 200), but returned success = false and an error message (ex: The subscription was canceled because the call failed when we tested the handler) it was considered a success and assumed it was going to get pings.

Since this would not be accurate, I feel it would be valid to treat it as an error in the same way as attempting pleaseNotify on a non-existing URL.